### PR TITLE
Get the front-end building, and the api server running too.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM rustlang/rust:nightly
+
+WORKDIR /usr/src/api
+
+RUN cargo install diesel_cli --no-default-features --features postgres
+
+RUN cargo install cargo-watch
+
+EXPOSE 8000
+
+VOLUME ["/cargo"]

--- a/README.md
+++ b/README.md
@@ -4,19 +4,5 @@ The project requires you to have [rust](https://www.rust-lang.org/en-US/install.
 
 In the base of the project run:
 ``` sh 
-export DATABASE_URL='postgres://postgres:secretpass@localhost:15432/queue'
-
-cd client
-npm install
-npm run build
-
-cd ..
-cargo install diesel_cli --vers=1.3.1 --no-default-features --features "postgres"
-
-docker-compose up -d
-
-diesel setup
-diesel migration run
-
-cargo run
+docker-compose up
 ```

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,0 +1,5 @@
+FROM node:8
+
+WORKDIR /usr/src/web
+
+RUN yarn

--- a/client/package.json
+++ b/client/package.json
@@ -5,11 +5,13 @@
   "dependencies": {
     "react": "^16.5.1",
     "react-dom": "^16.5.1",
-    "react-scripts": "1.1.5"
+    "react-scripts": "1.1.5",
+    "watch": "1.0.2"
   },
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
+    "watch": "watch 'npm run build' src public",
     "test": "react-scripts test --env=jsdom",
     "eject": "react-scripts eject"
   }

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -6755,6 +6755,13 @@ walker@~1.0.5:
   dependencies:
     makeerror "1.0.x"
 
+watch@1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/watch/-/watch-1.0.2.tgz#340a717bde765726fa0aa07d721e0147a551df0c"
+  dependencies:
+    exec-sh "^0.2.0"
+    minimist "^1.2.0"
+
 watch@~0.10.0:
   version "0.10.0"
   resolved "https://registry.yarnpkg.com/watch/-/watch-0.10.0.tgz#77798b2da0f9910d595f1ace5b0c2258521f21dc"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,10 +2,27 @@ version: '3'
 services:
   db:
     image: postgres
-    ports: 
-      - "15432:5432"
     volumes:
       - $PWD/tmp/db:/var/lib/postgresql/data
     environment:
       POSTGRES_PASSWORD: secretpass
       PGDATA: /tmp
+
+  web:
+    build: ./client
+    volumes:
+      - $PWD/client:/usr/src/web
+    command: bash -c "yarn && yarn watch"
+
+  api_server:
+    build: .
+    environment:
+      DATABASE_URL: postgres://postgres:secretpass@db:5432/queue
+      CARGO_TARGET_DIR: /cargo
+    ports:
+      - "8000:8000"
+    volumes:
+      - $PWD:/usr/src/api
+    links:
+      - db
+    command: bash -c "sleep 5 && diesel setup && cargo watch -x run"

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,9 +49,9 @@ fn main() {
     //     title(String),
     // }
 
-    println!("Now listening on localhost:8000");
+    println!("Now listening on 0.0.0.0:8000");
 
-    rouille::start_server("localhost:8000", move |request| {
+    rouille::start_server("0.0.0.0:8000", move |request| {
         let connection = establish_connection();
         // if we have a file in the client/build/ folder by the same name as the url, return that file.
         let response = rouille::match_assets(&request, "./client/build");


### PR DESCRIPTION
We should make the front-end build faster, but that can be a later step. 😉